### PR TITLE
Fixed locked items showing up in the options, removed R2API.

### DIFF
--- a/BetterCommandArtifact/ArtifactPlugin.csproj
+++ b/BetterCommandArtifact/ArtifactPlugin.csproj
@@ -57,10 +57,6 @@
       <HintPath>libs\ProBuilderMeshOps.dll</HintPath>
       <Private>false</Private>
     </Reference>
-    <Reference Include="R2API">
-      <HintPath>libs\R2API.dll</HintPath>
-      <Private>false</Private>
-    </Reference>
     <Reference Include="Rewired_Windows_Lib">
       <HintPath>libs\Rewired_Windows_Lib.dll</HintPath>
       <Private>false</Private>

--- a/BetterCommandArtifact/BetterCommandArtifact.cs
+++ b/BetterCommandArtifact/BetterCommandArtifact.cs
@@ -82,8 +82,9 @@ namespace BetterCommandArtifact
 
                 if (extraItems > 0)
                 {
-                    List<PickupIndex> additionalOptions = (from x in newSelection.ToList() orderby rnd.Next() select x).Where(x => Run.instance.IsPickupAvailable(x)).Take(extraItems).ToList();
-                    additionalOptions.Remove(pickupIndex);
+                    var add = (from x in newSelection.ToList() orderby rnd.Next() select x).Where(x => Run.instance.IsPickupAvailable(x));
+
+                    List<PickupIndex> additionalOptions = (from x in newSelection.ToList() orderby rnd.Next() select x).Where(x => (Run.instance.IsPickupAvailable(x) && x != pickupIndex)).Take(extraItems).ToList();
                     list.AddRange(additionalOptions);
                 }
 

--- a/BetterCommandArtifact/BetterCommandArtifact.cs
+++ b/BetterCommandArtifact/BetterCommandArtifact.cs
@@ -71,7 +71,14 @@ namespace BetterCommandArtifact
             else
             {
                 Random rnd = new Random();
-                List<PickupIndex> list = (from x in newSelection.ToList() orderby rnd.Next() select x).Where( x => Run.instance.IsPickupAvailable(x)).Take(itemAmount.Value).ToList();
+                List<PickupIndex> list = new List<PickupIndex> { pickupIndex };
+                if (itemAmount.Value - 1 > 0)
+                {
+                    List<PickupIndex> additionalOptions = (from x in newSelection.ToList() orderby rnd.Next() select x).Where(x => Run.instance.IsPickupAvailable(x)).Take(itemAmount.Value - 1).ToList();
+                    additionalOptions.Remove(pickupIndex);
+                    list.AddRange(additionalOptions);
+                }
+
                 array = new PickupPickerController.Option[list.Count];
                 for (int i = 0; i < list.Count; i++)
                 {

--- a/BetterCommandArtifact/BetterCommandArtifact.cs
+++ b/BetterCommandArtifact/BetterCommandArtifact.cs
@@ -71,10 +71,18 @@ namespace BetterCommandArtifact
             else
             {
                 Random rnd = new Random();
-                List<PickupIndex> list = new List<PickupIndex> { pickupIndex };
-                if (itemAmount.Value - 1 > 0)
+                List<PickupIndex> list = new List<PickupIndex>();
+
+                int extraItems = itemAmount.Value;
+                if (pickupIndex != PickupIndex.none)
                 {
-                    List<PickupIndex> additionalOptions = (from x in newSelection.ToList() orderby rnd.Next() select x).Where(x => Run.instance.IsPickupAvailable(x)).Take(itemAmount.Value - 1).ToList();
+                    list.Add(pickupIndex);
+                    extraItems--;
+                }
+
+                if (extraItems > 0)
+                {
+                    List<PickupIndex> additionalOptions = (from x in newSelection.ToList() orderby rnd.Next() select x).Where(x => Run.instance.IsPickupAvailable(x)).Take(extraItems).ToList();
                     additionalOptions.Remove(pickupIndex);
                     list.AddRange(additionalOptions);
                 }

--- a/BetterCommandArtifact/BetterCommandArtifact.cs
+++ b/BetterCommandArtifact/BetterCommandArtifact.cs
@@ -8,9 +8,16 @@ using UnityEngine.Networking;
 using PickupIndex = RoR2.PickupIndex;
 using PickupTransmutationManager = RoR2.PickupTransmutationManager;
 
+namespace R2API.Utils
+{
+    [AttributeUsage(AttributeTargets.Assembly)]
+    public class ManualNetworkRegistrationAttribute : Attribute
+    {
+    }
+}
+
 namespace BetterCommandArtifact
 {
-    [BepInDependency(R2API.R2API.PluginGUID)]
     [BepInPlugin(PluginGUID, PluginName, PluginVersion)]
     
     public class BetterCommandArtifact : BaseUnityPlugin
@@ -18,7 +25,7 @@ namespace BetterCommandArtifact
         public const string PluginGUID = PluginAuthor + "." + PluginName;
         public const string PluginAuthor = "Boooooop";
         public const string PluginName = "BetterCommandArtifact";
-        public const string PluginVersion = "1.0.0";
+        public const string PluginVersion = "1.0.1";
 
         public static ConfigFile configFile = new ConfigFile(Paths.ConfigPath + "\\BetterCommandArtifact.cfg", true);
 
@@ -64,7 +71,7 @@ namespace BetterCommandArtifact
             else
             {
                 Random rnd = new Random();
-                List<PickupIndex> list = (from x in newSelection.ToList() orderby rnd.Next() select x).Take(itemAmount.Value).ToList();
+                List<PickupIndex> list = (from x in newSelection.ToList() orderby rnd.Next() select x).Where( x => Run.instance.IsPickupAvailable(x)).Take(itemAmount.Value).ToList();
                 array = new PickupPickerController.Option[list.Count];
                 for (int i = 0; i < list.Count; i++)
                 {


### PR DESCRIPTION
Just a minor update to fix locked/disabled items showing up in the options list.
Also guarantees the original dropped item will show up in the first slot.
I noticed this mod doesn't actually need R2API to work, so I removed all references to it. You should update your manifest.json and replace the R2API dependency with "RiskofThunder-HookGenPatcher-1.2.3"
It would also be good to update your MMHook_RoR2.dll and RoR2.dll dependencies to the latest versions just to be safe.

I think the default options could be reduced to 3 to mimic void potentials, but there's no need to change that if you're fine with it at 5.